### PR TITLE
Incluida a versão da API na url

### DIFF
--- a/src/Api/Application.php
+++ b/src/Api/Application.php
@@ -9,7 +9,7 @@ use Api\Beer\Provider\BeerBuilder;
 
 class Application extends SilexApplication
 {
-    private $baseRouteApi	= '/api';
+    private $baseRouteApi	= '/api/v1';
 
     public function __construct(array $values = [])
     {


### PR DESCRIPTION
É uma boa prática colocar a versão  da API na URL. Assim você pode criar uma nova versão no futuro, criar novas funcionalidades ou mesmo mudar elas sem influenciar os clientes que estão usando a V1. É uma prática adotada por empresas como o Google e Twitter.
